### PR TITLE
Mise au carré

### DIFF
--- a/tryalgo/rectangles_from_points.py
+++ b/tryalgo/rectangles_from_points.py
@@ -19,7 +19,7 @@ def rectangles_from_points(S):
             px, py = S[i]
             qx, qy = S[j]
             center = (px + qx, py + qy)
-            dist = (px - qx) * (px - qx) + (py - qy) * (py - qy)
+            dist = (px - qx) ** 2 + (py - qy) ** 2
             sign = (center, dist)
             if sign in pairs:
                 answ += len(pairs[sign])


### PR DESCRIPTION
Page 170, dans `rectangles_from_points()`, on devrait utiliser `** 2` pour mettre au carré, pas un calcul de `(px - qx) * (px - qx)`.

> *Note :* le même soucis peut être présent ailleurs.