### PR TITLE
Remove ugly global variables

### DIFF
--- a/tryalgo/strongly_connected_components.py
+++ b/tryalgo/strongly_connected_components.py
@@ -22,6 +22,7 @@ def tarjan_recursif(graph):
     dfs_num = [None] * len(graph)
 
     def dfs(node):
+        """we modify sccp, waiting, waits, dfs_time and dfs_num"""
         nonlocal dfs_time
         waiting.append(node)           # nouveau nœud attend
         waits[node] = True

--- a/tryalgo/strongly_connected_components.py
+++ b/tryalgo/strongly_connected_components.py
@@ -15,7 +15,6 @@ def tarjan_recursif(graph):
     :returns: list of lists for each component
     :complexity: linear
     """
-    global sccp, waiting, dfs_time, dfs_num
     sccp = []
     waiting = []
     waits = [False] * len(graph)
@@ -23,7 +22,7 @@ def tarjan_recursif(graph):
     dfs_num = [None] * len(graph)
 
     def dfs(node):
-        global sccp, waiting, dfs_time, dfs_num
+        nonlocal dfs_time
         waiting.append(node)           # nouveau nœud attend
         waits[node] = True
         dfs_num[node] = dfs_time       # marquer visite


### PR DESCRIPTION
You don't have to set persistant objects (like lists) as global or even nonlocal thanks to closure.
But, to modify the int dfs_time in the context of the tarjan_recursif, you just have to make it nonlocal. Python is going to look in every parent namespace to find such a variable.

To quote Guido :

> Namespaces are one honking great idea -- let's do more of those!