### PR TITLE
Corrected doc

### DIFF
--- a/tryalgo/knuth_morris_pratt_border.py
+++ b/tryalgo/knuth_morris_pratt_border.py
@@ -14,7 +14,7 @@ def maximum_border_length(w):
     """Maximum string borders by Knuth-Morris-Pratt
 
     :param w: string
-    :returns: table l such that l[i] is the longest border length of w[:i + 1]
+    :returns: table l such that l[i] is the longest border length of w[:i]
     :complexity: linear
     """
     n = len(w)


### PR DESCRIPTION
We can see the error with a simple example:

    >>> maximum_border_length('abcab')
    [0, 0, 0, 0, 1, 2]

and here l[4] = 1 and s[:5] = 'abcab' but s[:4] = 'abca'