### PR TITLE
Revert "Remove ugly global variables"

### DIFF
--- a/tryalgo/strongly_connected_components.py
+++ b/tryalgo/strongly_connected_components.py
@@ -15,6 +15,7 @@ def tarjan_recursif(graph):
     :returns: list of lists for each component
     :complexity: linear
     """
+    global sccp, waiting, dfs_time, dfs_num
     sccp = []
     waiting = []
     waits = [False] * len(graph)
@@ -22,8 +23,7 @@ def tarjan_recursif(graph):
     dfs_num = [None] * len(graph)
 
     def dfs(node):
-        """we modify sccp, waiting, waits, dfs_time and dfs_num"""
-        nonlocal dfs_time
+        global sccp, waiting, dfs_time, dfs_num
         waiting.append(node)           # nouveau nœud attend
         waits[node] = True
         dfs_num[node] = dfs_time       # marquer visite


### PR DESCRIPTION
Reverts jilljenn/tryalgo#33

non_local is a keyword that works only in Python3. 
We want our code to work for the moment on both versions 2 and 3.
