### PR TITLE
List current theme as a dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx-gallery
-sphinx_rtd_theme
+pydata-sphinx-theme


### PR DESCRIPTION
Currently, the theme is the pydata one, not the read the doc's one, cf: [conf.py](https://github.com/jilljenn/tryalgo/blob/0e73d70e240734326eef33e13d3d172c7afe529c/docs/conf.py#L134)

Thanks for maintaining this repo !